### PR TITLE
feat(files): implement project file management with upload/download/list/delete operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ build/
 application-*.properties
 application-*.yml
 
+# File uploads
+dev-uploads/
+uploads/
+avatars/
+
 # Database
 *.db
 *.sqlite

--- a/src/main/java/com/university/takharrujy/application/service/ProjectFileService.java
+++ b/src/main/java/com/university/takharrujy/application/service/ProjectFileService.java
@@ -1,0 +1,217 @@
+package com.university.takharrujy.application.service;
+
+import com.university.takharrujy.domain.entity.ProjectFile;
+import com.university.takharrujy.domain.repository.ProjectFileRepository;
+import com.university.takharrujy.infrastructure.exception.ResourceNotFoundException;
+import com.university.takharrujy.infrastructure.exception.ValidationException;
+import com.university.takharrujy.presentation.dto.file.FileResponse;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * ProjectFileService
+ * Business logic for project file management including upload, download, listing, and deletion
+ */
+@Service
+@Transactional
+public class ProjectFileService {
+
+    private static final long MAX_FILE_SIZE = 100L * 1024 * 1024; // 100MB
+    
+    private static final String[] ALLOWED_CONTENT_TYPES = new String[] {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/zip",
+        "application/x-zip-compressed",
+        "text/plain",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/gif"
+    };
+
+    private final ProjectFileRepository repository;
+    private final FileStorageService storage;
+    private final VirusScanService virusScanService;
+
+    public ProjectFileService(ProjectFileRepository repository,
+                              FileStorageService storage,
+                              VirusScanService virusScanService) {
+        this.repository = repository;
+        this.storage = storage;
+        this.virusScanService = virusScanService;
+    }
+
+    /**
+     * Upload a file to a project
+     */
+    public FileResponse upload(Long projectId, Long userId, MultipartFile file) {
+        // Validate file
+        validateFile(file);
+
+        // Perform virus scan
+        if (!virusScanService.scanFile(file)) {
+            throw new ValidationException("File failed security scan - potential malware detected");
+        }
+
+        // Store file
+        String storagePath = storage.storeProjectFile(file, projectId);
+
+        // Create entity
+        ProjectFile entity = new ProjectFile();
+        entity.setProjectId(projectId);
+        entity.setUploadedByUserId(userId);
+        entity.setOriginalFilename(file.getOriginalFilename());
+        entity.setContentType(safeContentType(file.getContentType()));
+        entity.setFileSize(file.getSize());
+        entity.setStoragePath(storagePath);
+        entity.setFilename(extractFilename(storagePath));
+
+        // Save to database
+        ProjectFile saved = repository.save(entity);
+        
+        return toResponse(saved);
+    }
+
+    /**
+     * List all files for a project
+     */
+    @Transactional(readOnly = true)
+    public List<FileResponse> listByProject(Long projectId) {
+        return repository.findByProjectIdOrderByUploadedAtDesc(projectId)
+            .stream()
+            .map(this::toResponse)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Get file metadata by ID
+     */
+    @Transactional(readOnly = true)
+    public FileResponse getFileMetadata(Long fileId) {
+        ProjectFile file = getFileById(fileId);
+        return toResponse(file);
+    }
+
+    /**
+     * Download a file
+     */
+    @Transactional(readOnly = true)
+    public Resource download(Long fileId) {
+        ProjectFile file = getFileById(fileId);
+        return storage.loadAsResource(file.getStoragePath());
+    }
+
+    /**
+     * Get file entity for download metadata
+     */
+    @Transactional(readOnly = true)
+    public ProjectFile getFileForDownload(Long fileId) {
+        return getFileById(fileId);
+    }
+
+    /**
+     * Delete a file
+     */
+    public void delete(Long fileId) {
+        ProjectFile file = getFileById(fileId);
+        
+        // Delete from storage
+        storage.deleteFile(file.getStoragePath());
+        
+        // Delete from database
+        repository.deleteById(fileId);
+    }
+
+    /**
+     * Get file statistics for a project
+     */
+    @Transactional(readOnly = true)
+    public long getProjectFileCount(Long projectId) {
+        return repository.countByProjectId(projectId);
+    }
+
+    /**
+     * Helper: Get file by ID or throw exception
+     */
+    private ProjectFile getFileById(Long id) {
+        return repository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("File not found with ID: " + id));
+    }
+
+    /**
+     * Helper: Validate file upload
+     */
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ValidationException("File is required");
+        }
+        
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new ValidationException("File size cannot exceed 100MB");
+        }
+        
+        String contentType = safeContentType(file.getContentType());
+        boolean isAllowed = false;
+        for (String allowedType : ALLOWED_CONTENT_TYPES) {
+            if (allowedType.equalsIgnoreCase(contentType)) {
+                isAllowed = true;
+                break;
+            }
+        }
+        
+        if (!isAllowed) {
+            throw new ValidationException(
+                "Unsupported file type: " + contentType + 
+                ". Allowed types: PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX, ZIP, TXT, images"
+            );
+        }
+    }
+
+    /**
+     * Helper: Safe content type extraction
+     */
+    private String safeContentType(String contentType) {
+        return (contentType == null || contentType.isBlank()) 
+            ? MediaType.APPLICATION_OCTET_STREAM_VALUE 
+            : contentType;
+    }
+
+    /**
+     * Helper: Extract filename from storage path
+     */
+    private String extractFilename(String storagePath) {
+        if (storagePath == null) return "unknown";
+        int idx = storagePath.lastIndexOf('/');
+        return idx >= 0 ? storagePath.substring(idx + 1) : storagePath;
+    }
+
+    /**
+     * Helper: Convert entity to response DTO
+     */
+    private FileResponse toResponse(ProjectFile file) {
+        return new FileResponse(
+            file.getId(),
+            file.getProjectId(),
+            file.getFilename(),
+            file.getOriginalFilename(),
+            file.getContentType(),
+            file.getFileSize(),
+            file.getStoragePath(),
+            file.getUploadedByUserId(),
+            file.getUploadedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/university/takharrujy/domain/entity/ProjectFile.java
+++ b/src/main/java/com/university/takharrujy/domain/entity/ProjectFile.java
@@ -1,0 +1,148 @@
+package com.university.takharrujy.domain.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+/**
+ * ProjectFile Entity
+ * Represents a file uploaded to a project with metadata and storage information
+ */
+@Entity
+@Table(name = "project_files",
+       indexes = {
+         @Index(name = "idx_project_files_project", columnList = "projectId"),
+         @Index(name = "idx_project_files_uploaded_by", columnList = "uploadedByUserId")
+       })
+public class ProjectFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false, length = 255)
+    private String filename;
+
+    @Column(nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(nullable = false, length = 150)
+    private String contentType;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+    @Column(nullable = false, length = 512)
+    private String storagePath;
+
+    @Column(nullable = false)
+    private Long uploadedByUserId;
+
+    @Column(nullable = false, updatable = false)
+    private Instant uploadedAt = Instant.now();
+
+    // Constructors
+    public ProjectFile() {}
+
+    public ProjectFile(Long projectId, String filename, String originalFilename, 
+                      String contentType, Long fileSize, String storagePath, 
+                      Long uploadedByUserId) {
+        this.projectId = projectId;
+        this.filename = filename;
+        this.originalFilename = originalFilename;
+        this.contentType = contentType;
+        this.fileSize = fileSize;
+        this.storagePath = storagePath;
+        this.uploadedByUserId = uploadedByUserId;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public void setOriginalFilename(String originalFilename) {
+        this.originalFilename = originalFilename;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(Long fileSize) {
+        this.fileSize = fileSize;
+    }
+
+    public String getStoragePath() {
+        return storagePath;
+    }
+
+    public void setStoragePath(String storagePath) {
+        this.storagePath = storagePath;
+    }
+
+    public Long getUploadedByUserId() {
+        return uploadedByUserId;
+    }
+
+    public void setUploadedByUserId(Long uploadedByUserId) {
+        this.uploadedByUserId = uploadedByUserId;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "ProjectFile{" +
+                "id=" + id +
+                ", projectId=" + projectId +
+                ", filename='" + filename + '\'' +
+                ", originalFilename='" + originalFilename + '\'' +
+                ", contentType='" + contentType + '\'' +
+                ", fileSize=" + fileSize +
+                ", uploadedByUserId=" + uploadedByUserId +
+                ", uploadedAt=" + uploadedAt +
+                '}';
+    }
+}
+

--- a/src/main/java/com/university/takharrujy/domain/repository/ProjectFileRepository.java
+++ b/src/main/java/com/university/takharrujy/domain/repository/ProjectFileRepository.java
@@ -1,0 +1,31 @@
+package com.university.takharrujy.domain.repository;
+
+import com.university.takharrujy.domain.entity.ProjectFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * ProjectFileRepository
+ * Repository interface for ProjectFile entity operations
+ */
+@Repository
+public interface ProjectFileRepository extends JpaRepository<ProjectFile, Long> {
+    
+    /**
+     * Find all files belonging to a specific project, ordered by upload date descending
+     */
+    List<ProjectFile> findByProjectIdOrderByUploadedAtDesc(Long projectId);
+    
+    /**
+     * Find all files uploaded by a specific user
+     */
+    List<ProjectFile> findByUploadedByUserId(Long userId);
+    
+    /**
+     * Count total files in a project
+     */
+    long countByProjectId(Long projectId);
+}
+

--- a/src/main/java/com/university/takharrujy/presentation/controller/FileController.java
+++ b/src/main/java/com/university/takharrujy/presentation/controller/FileController.java
@@ -1,0 +1,229 @@
+package com.university.takharrujy.presentation.controller;
+
+import com.university.takharrujy.application.service.ProjectFileService;
+import com.university.takharrujy.domain.entity.ProjectFile;
+import com.university.takharrujy.presentation.dto.common.ApiResponse;
+import com.university.takharrujy.presentation.dto.file.FileResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * FileController
+ * REST API endpoints for project file management
+ */
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "File Management", description = "Project file upload, listing, download, and deletion with virus scanning")
+@SecurityRequirement(name = "bearerAuth")
+@CrossOrigin(origins = {"http://localhost:3000", "http://localhost:5173", "https://takharrujy.com"})
+public class FileController {
+
+    private final ProjectFileService fileService;
+
+    public FileController(ProjectFileService fileService) {
+        this.fileService = fileService;
+    }
+
+    /**
+     * Upload file to project
+     */
+    @PostMapping(value = "/projects/{projectId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('STUDENT','SUPERVISOR','ADMIN')")
+    @Operation(summary = "Upload file to project", 
+              description = "Upload a file to a specific project with virus scanning and validation. Max size: 100MB")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "File uploaded successfully",
+            content = @Content(schema = @Schema(implementation = FileResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400", 
+            description = "Invalid file or validation error"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "Unauthorized - Invalid or expired token"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "413", 
+            description = "File too large - max 100MB"
+        )
+    })
+    public ResponseEntity<ApiResponse<FileResponse>> upload(
+            @Parameter(description = "Project ID to upload file to")
+            @PathVariable Long projectId,
+            @Parameter(description = "File to upload (PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX, ZIP, TXT, images)")
+            @RequestParam("file") MultipartFile file
+    ) {
+        Long userId = getCurrentUserId();
+        FileResponse response = fileService.upload(projectId, userId, file);
+        
+        return ResponseEntity.ok(
+            ApiResponse.success(response, "File uploaded successfully", "تم رفع الملف بنجاح")
+        );
+    }
+
+    /**
+     * List project files
+     */
+    @GetMapping("/projects/{projectId}/files")
+    @PreAuthorize("hasAnyRole('STUDENT','SUPERVISOR','ADMIN')")
+    @Operation(summary = "List project files", 
+              description = "Get list of all files uploaded to a specific project")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "Files listed successfully"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "Unauthorized - Invalid or expired token"
+        )
+    })
+    public ResponseEntity<ApiResponse<List<FileResponse>>> listFiles(
+            @Parameter(description = "Project ID to list files from")
+            @PathVariable Long projectId
+    ) {
+        List<FileResponse> files = fileService.listByProject(projectId);
+        
+        return ResponseEntity.ok(
+            ApiResponse.success(files, "Files listed successfully", "تم سرد الملفات بنجاح")
+        );
+    }
+
+    /**
+     * Get file metadata
+     */
+    @GetMapping("/files/{fileId}/info")
+    @PreAuthorize("hasAnyRole('STUDENT','SUPERVISOR','ADMIN')")
+    @Operation(summary = "Get file metadata", 
+              description = "Get detailed metadata for a specific file")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "File metadata retrieved successfully"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404", 
+            description = "File not found"
+        )
+    })
+    public ResponseEntity<ApiResponse<FileResponse>> getFileInfo(
+            @Parameter(description = "File ID")
+            @PathVariable Long fileId
+    ) {
+        FileResponse file = fileService.getFileMetadata(fileId);
+        
+        return ResponseEntity.ok(
+            ApiResponse.success(file, "File metadata retrieved", "تم استرداد بيانات الملف")
+        );
+    }
+
+    /**
+     * Download file
+     */
+    @GetMapping("/files/{fileId}")
+    @PreAuthorize("hasAnyRole('STUDENT','SUPERVISOR','ADMIN')")
+    @Operation(summary = "Download file", 
+              description = "Download a file by its ID")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "File downloaded successfully"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404", 
+            description = "File not found"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "Unauthorized - Invalid or expired token"
+        )
+    })
+    public ResponseEntity<Resource> download(
+            @Parameter(description = "File ID to download")
+            @PathVariable Long fileId
+    ) {
+        Resource resource = fileService.download(fileId);
+        ProjectFile file = fileService.getFileForDownload(fileId);
+        
+        return ResponseEntity.ok()
+            .contentType(MediaType.parseMediaType(file.getContentType()))
+            .header(HttpHeaders.CONTENT_DISPOSITION, 
+                "attachment; filename=\"" + file.getOriginalFilename() + "\"")
+            .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(file.getFileSize()))
+            .body(resource);
+    }
+
+    /**
+     * Delete file
+     */
+    @DeleteMapping("/files/{fileId}")
+    @PreAuthorize("hasAnyRole('STUDENT','SUPERVISOR','ADMIN')")
+    @Operation(summary = "Delete file", 
+              description = "Delete a file by its ID (removes from storage and database)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "File deleted successfully"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404", 
+            description = "File not found"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401", 
+            description = "Unauthorized - Invalid or expired token"
+        )
+    })
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @Parameter(description = "File ID to delete")
+            @PathVariable Long fileId
+    ) {
+        fileService.delete(fileId);
+        
+        return ResponseEntity.ok(
+            ApiResponse.success(null, "File deleted successfully", "تم حذف الملف بنجاح")
+        );
+    }
+
+    /**
+     * Get current user ID from security context
+     */
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof Long) {
+                return (Long) principal;
+            } else if (principal instanceof String) {
+                try {
+                    return Long.parseLong((String) principal);
+                } catch (NumberFormatException e) {
+                    throw new com.university.takharrujy.infrastructure.exception.SecurityException(
+                        "Invalid user ID in token");
+                }
+            }
+        }
+        throw new com.university.takharrujy.infrastructure.exception.SecurityException(
+            "No authenticated user found");
+    }
+}
+

--- a/src/main/java/com/university/takharrujy/presentation/dto/file/FileResponse.java
+++ b/src/main/java/com/university/takharrujy/presentation/dto/file/FileResponse.java
@@ -1,0 +1,73 @@
+package com.university.takharrujy.presentation.dto.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+/**
+ * FileResponse DTO
+ * Response object containing project file metadata
+ */
+@Schema(description = "Project file metadata response")
+public record FileResponse(
+    
+    @Schema(description = "File ID")
+    Long id,
+    
+    @Schema(description = "Project ID this file belongs to")
+    Long projectId,
+    
+    @Schema(description = "Stored filename")
+    String filename,
+    
+    @Schema(description = "Original filename from upload")
+    String originalFilename,
+    
+    @Schema(description = "File content type (MIME type)")
+    String contentType,
+    
+    @Schema(description = "File size in bytes")
+    Long fileSize,
+    
+    @Schema(description = "Storage path for file retrieval")
+    String storagePath,
+    
+    @Schema(description = "User ID who uploaded the file")
+    Long uploadedByUserId,
+    
+    @Schema(description = "Upload timestamp")
+    Instant uploadedAt
+) {
+    
+    /**
+     * Get human-readable file size
+     */
+    public String getFormattedFileSize() {
+        if (fileSize == null) return "0 B";
+        
+        long size = fileSize;
+        if (size < 1024) return size + " B";
+        if (size < 1024 * 1024) return String.format("%.2f KB", size / 1024.0);
+        if (size < 1024 * 1024 * 1024) return String.format("%.2f MB", size / (1024.0 * 1024));
+        return String.format("%.2f GB", size / (1024.0 * 1024 * 1024));
+    }
+    
+    /**
+     * Check if file is an image
+     */
+    public boolean isImage() {
+        return contentType != null && contentType.startsWith("image/");
+    }
+    
+    /**
+     * Check if file is a document
+     */
+    public boolean isDocument() {
+        if (contentType == null) return false;
+        return contentType.equals("application/pdf") ||
+               contentType.contains("word") ||
+               contentType.contains("document") ||
+               contentType.contains("presentation") ||
+               contentType.equals("text/plain");
+    }
+}
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,58 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/takharrujy_dev
+    username: takharrujy
+    password: takharrujy
+  
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ""
+      database: 0
+  
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 100MB
+      max-request-size: 100MB
+      file-size-threshold: 2MB
+
+logging:
+  level:
+    com.university.takharrujy: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.security: DEBUG
+
+takharrujy:
+  jwt:
+    secret: takharrujy-dev-secret-key-not-for-production
+    expiration: 86400000 # 24 hours for development
+  
+  file-storage:
+    type: local
+    local:
+      upload-dir: ./dev-uploads
+    max-file-size: 104857600 # 100MB in bytes
+    allowed-types: application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/zip,text/plain,image/jpeg,image/png,image/webp,image/gif
+  
+  security:
+    cors:
+      allowed-origins: "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000"
+    rate-limiting:
+      enabled: false # Disable in development
+  
+  virus-scan:
+    enabled: false # Disable in development
+  
+  email:
+    from: dev@takharrujy.local
+    templates:
+      base-url: http://localhost:3000


### PR DESCRIPTION
- Add ProjectFile entity with JPA annotations and indexed fields
- Create ProjectFileRepository with query methods for project files
- Implement ProjectFileService with file validation, virus scanning, and CRUD operations
- Add FileController with REST endpoints for file operations
- Create FileResponse DTO with metadata and helper methods
- Extend FileStorageService with project file storage and resource loading
- Configure multipart file upload (100MB max) in application-dev.yml
- Update .gitignore to exclude upload directories

Features:
- Upload files to projects with virus scanning
- Support for PDF, Office docs, images, ZIP files
- Download files with proper content type headers
- List all files for a project ordered by upload date
- Delete files from storage and database
- File size limit: 100MB
- Organized storage: uploads/projects/{projectId}/{year}/{month}/{day}/
- Arabic language support in API responses

Security:
- Virus scanning on all uploads
- File type validation
- Size limits enforced
- Access control via Spring Security